### PR TITLE
feat: add delta for enhanced git diffs

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -17,6 +17,7 @@
     "lazygit@latest",
     "nodejs@latest",
     "go@latest"
+    "delta@latest",
   ],
   "shell": {
     "init_hook": "",

--- a/dotfiles/home/.gitconfig
+++ b/dotfiles/home/.gitconfig
@@ -5,6 +5,7 @@
 [core]
 	editor = nvim
 	autocrlf=input
+	pager = delta
 
 [color]
 	ui = true
@@ -35,4 +36,45 @@
 [credential "https://gist.github.com"]
 	helper = 
 	helper = !gh auth git-credential
+
+[interactive]
+	diffFilter = delta --color-only --features=interactive
+
+[delta]
+	features = decorations
+	navigate = true
+	light = false
+
+[delta "decorations"]
+	commit-decoration-style = blue ol
+	commit-style = raw
+	file-style = omit
+	hunk-header-decoration-style = blue box
+	hunk-header-file-style = red
+	hunk-header-line-number-style = "#067a00"
+	hunk-header-style = file line-number syntax
+
+[alias]
+	# Common shortcuts
+	st = status
+	co = checkout
+	br = branch
+	ci = commit
+	ca = commit -a
+	cm = commit -m
+	cam = commit -am
+	
+	# Pretty logs
+	lg = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
+	lga = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --all
+	
+	# Diff shortcuts
+	d = diff
+	dc = diff --cached
+	ds = diff --stat
+	
+	# Stash shortcuts
+	sl = stash list
+	sa = stash apply
+	ss = stash save
 


### PR DESCRIPTION
## Summary
Add delta for syntax-highlighted git diffs and useful git aliases.

## Changes
- Add `delta@latest` package to devbox.json
- Configure delta as git pager with syntax highlighting
- Add common git aliases (st, co, br, ci, lg, etc.)
- Set up interactive diff filtering for better `git add -p`

Delta makes git diffs much more readable with syntax highlighting and line numbers.